### PR TITLE
Revert "Add Boost.Locale as a dependency for the build"

### DIFF
--- a/tc-apt.sh
+++ b/tc-apt.sh
@@ -19,8 +19,7 @@ apt-get -qq -y install \
 	pixz \
 	zip \
 	zlib1g-dev \
-	unzip \
-	libboost-locale-dev
+	unzip
 
 echo 'oracle-java8-installer shared/accepted-oracle-license-v1-1 select true' | debconf-set-selections
 add-apt-repository --yes ppa:webupd8team/java && apt-get -qq update

--- a/tc-brew.sh
+++ b/tc-brew.sh
@@ -28,8 +28,7 @@ fi;
 
 # coreutils, pyenv-virtualenv required for build of tensorflow
 # node@6 pkg-config sox swig required for later build of deepspeech
-# boost required by native_client decoder
-all_pkgs="coreutils pyenv-virtualenv node@6 pkg-config sox swig boost"
+all_pkgs="coreutils pyenv-virtualenv node@6 pkg-config sox swig"
 
 for pkg in ${all_pkgs};
 do


### PR DESCRIPTION
This reverts commit 6997437088190de49c4e63bc3377894015fdbde0.

Bazel can't handle external dependencies that live in different paths depending on the platform, so I'll just vendor the necessary headers.