### PR TITLE
Switch to heavy OSX worker

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -20,7 +20,7 @@ tasks:
 
     scopes: [
       "queue:create-task:lowest:{{ taskcluster.docker.provisionerId }}/deepspeech-worker",
-      "queue:create-task:lowest:localprovisioner/deepspeech-macos",
+      "queue:create-task:lowest:deepspeech-provisioner/ds-macos-heavy",
       "queue:route:index.project.deepspeech.*",
       "queue:scheduler-id:taskcluster-github"
     ]

--- a/taskcluster/darwin-opt-base.tyml
+++ b/taskcluster/darwin-opt-base.tyml
@@ -42,8 +42,7 @@ payload:
       - "-cxe"
       - >
         export TASKCLUSTER_ARTIFACTS="$(pwd)/public/" &&
-        export TASKCLUSTER_TASK_ROOT="$(pwd)" &&
-        export TASKCLUSTER_TASK_DIR="$(dirname `pwd`)/task-${event.head.sha}" &&
+        export TASKCLUSTER_TASK_DIR="$(pwd)" &&
         mkdir -p $TASKCLUSTER_TASK_DIR/DeepSpeech/ &&
         env &&
         git clone --quiet ${event.head.repo.url} $TASKCLUSTER_TASK_DIR/DeepSpeech/tf/ &&
@@ -51,8 +50,7 @@ payload:
         $TASKCLUSTER_TASK_DIR/DeepSpeech/tf/tc-brew.sh &&
         $TASKCLUSTER_TASK_DIR/DeepSpeech/tf/tc-setup.sh &&
         $TASKCLUSTER_TASK_DIR/DeepSpeech/tf/tc-build.sh &&
-        $TASKCLUSTER_TASK_DIR/DeepSpeech/tf/tc-package.sh;
-        cd $TASKCLUSTER_TASK_ROOT && rm -fr $TASKCLUSTER_TASK_DIR
+        $TASKCLUSTER_TASK_DIR/DeepSpeech/tf/tc-package.sh
 
   artifacts:
     - type: "directory"

--- a/taskcluster/worker.cyml
+++ b/taskcluster/worker.cyml
@@ -4,5 +4,5 @@ taskcluster:
     provisionerId: aws-provisioner-v1
     workerType: deepspeech-worker
   generic:
-    provisionerId: localprovisioner
-    workerType: deepspeech-macos
+    provisionerId: deepspeech-provisioner
+    workerType: ds-macos-heavy

--- a/tc-package.sh
+++ b/tc-package.sh
@@ -9,6 +9,19 @@ mkdir -p ${TASKCLUSTER_ARTIFACTS} || true
 cp ${DS_ROOT_TASK}/DeepSpeech/tf/bazel-bin/tensorflow/libtensorflow_cc.so ${TASKCLUSTER_ARTIFACTS}
 cp ${DS_ROOT_TASK}/DeepSpeech/tf/bazel-bin/tensorflow/tools/graph_transforms/transform_graph ${TASKCLUSTER_ARTIFACTS}
 
-artifact_root_dir=$(dirname "${DS_ROOT_TASK}")
-artifact_tar_dir=$(basename "${DS_ROOT_TASK}")
-tar -C ${artifact_root_dir} -cf - ${artifact_tar_dir} | pixz -9 > ${TASKCLUSTER_ARTIFACTS}/home.tar.xz
+# It seems that bsdtar and gnutar are behaving a bit differently on the way
+# they deal with --exclude="./public/*" ; this caused ./DeepSpeech/tensorflow/core/public/
+# to be ditched when we just wanted to get rid of ./public/ on OSX.
+# Switching to gnutar (already needed for the --transform on DeepSpeech tasks)
+# does the trick.
+TAR=tar
+TAR_EXCLUDE="--exclude=./dls/*"
+if [ "${OS}" = "Darwin" ]; then
+    TAR=gtar
+    TAR_EXCLUDE="--exclude=./dls/* --exclude=./public/* --exclude=./generic-worker/* --exclude=./homebrew/* --exclude=./homebrew.cache/*"
+fi;
+
+# Make a tar of
+#  - /home/build-user/ (linux
+#  - /Users/build-user/TaskCluster/HeavyTasks/X/ (OSX)
+${TAR} -C ${DS_ROOT_TASK} ${TAR_EXCLUDE} -cf - . | pixz -9 > ${TASKCLUSTER_ARTIFACTS}/home.tar.xz

--- a/tc-vars.sh
+++ b/tc-vars.sh
@@ -15,10 +15,9 @@ if [ "${OS}" = "Linux" ]; then
     CUDNN_URL=http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz
     CUDNN_SHA256=c10719b36f2dd6e9ddc63e3189affaa1a94d7d027e63b71c3f64d449ab0645ce
 elif [ "${OS}" = "Darwin" ]; then
-    if [ -z "${TASKCLUSTER_TASK_DIR}" -o -z "${TASKCLUSTER_ARTIFACTS}" -o -z "${TASKCLUSTER_TASK_ROOT}" ]; then
+    if [ -z "${TASKCLUSTER_TASK_DIR}" -o -z "${TASKCLUSTER_ARTIFACTS}" ]; then
         echo "Inconsistent OSX setup: missing some vars."
         echo "TASKCLUSTER_TASK_DIR=${TASKCLUSTER_TASK_DIR}"
-        echo "TASKCLUSTER_TASK_ROOT=${TASKCLUSTER_TASK_ROOT}"
         echo "TASKCLUSTER_ARTIFACTS=${TASKCLUSTER_ARTIFACTS}"
         exit 1
     fi;
@@ -89,8 +88,12 @@ export CC_OPT_FLAGS
 
 if [ "${OS}" = "Darwin" ]; then
     BAZEL_OUTPUT_CACHE_DIR="${DS_ROOT_TASK}/.bazel_cache/"
-    mkdir -p ${BAZEL_OUTPUT_CACHE_DIR} || true
-    BAZEL_OUTPUT_USER_ROOT="--output_user_root ${BAZEL_OUTPUT_CACHE_DIR}"
+    BAZEL_OUTPUT_CACHE_INSTANCE="${BAZEL_OUTPUT_CACHE_DIR}/output/"
+    mkdir -p ${BAZEL_OUTPUT_CACHE_INSTANCE} || true
+
+    # We need both to ensure stable path ; default value for output_base is some
+    # MD5 value.
+    BAZEL_OUTPUT_USER_ROOT="--output_user_root ${BAZEL_OUTPUT_CACHE_DIR} --output_base ${BAZEL_OUTPUT_CACHE_INSTANCE}"
     export BAZEL_OUTPUT_USER_ROOT
 fi;
 


### PR DESCRIPTION
Relying on multiple generic-worker on OSX will need us to stop using the
hack of /Users/build-user/TaskCluster/Tasks/task-<SHA1>/ and use the
proper task's directory which is defined at
/Users/build-user/TaskCluster/Tasks/task_<TIME>/, with the downside that
"client-side" use of home.tar.xz on OSX will need to rewrite the paths
since task dir will include the worker's instance, following that
pattern, X being the instance number:
/Users/build-user/TaskCluster/(Heavy|Light)Tasks/X/