### PR TITLE
Including memmapped_file_system for Windows in the BUILD file

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -920,7 +920,6 @@ tf_cuda_library(
         "util/util.h",
         "util/work_sharder.h",
     ] + select({
-        "//tensorflow:windows": [],
         "//conditions:default": [
             "util/memmapped_file_system.h",
             "util/memmapped_file_system_writer.h",
@@ -2519,7 +2518,6 @@ FRAMEWORK_INTERNAL_PRIVATE_HEADERS = [
         "util/version_info.cc",
     ],
 ) + select({
-    "//tensorflow:windows": [],
     "//conditions:default": [
         "util/memmapped_file_system.h",
         "util/memmapped_file_system_writer.h",
@@ -2621,7 +2619,6 @@ tf_cuda_library(
             "util/env_var.cc",
         ],
     ) + select({
-        "//tensorflow:windows": [],
         "//conditions:default": [
             "util/memmapped_file_system.cc",
             "util/memmapped_file_system_writer.cc",

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -131,13 +131,14 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
     tf_http_archive(
         name = "eigen_archive",
-        build_file = clean_dep("//third_party:eigen.BUILD"),
         sha256 = "d956415d784fa4e42b6a2a45c32556d6aec9d0a3d8ef48baee2522ab762556a9",
         strip_prefix = "eigen-eigen-fd6845384b86",
         urls = [
             "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
             "https://bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
         ],
+        build_file = clean_dep("//third_party:eigen.BUILD"),
+        patch_file = clean_dep("//third_party:eigen_half.patch"),
     )
 
     tf_http_archive(

--- a/third_party/eigen_half.patch
+++ b/third_party/eigen_half.patch
@@ -1,0 +1,22 @@
+--- Eigen/src/Core/arch/CUDA/Half.h	2018-06-22 18:09:44.000000000 -0400
++++ ./Eigen/src/Core/arch/CUDA/Half.h	2018-07-25 01:19:55.462313100 -0400
+@@ -209,7 +209,7 @@
+ // conversion steps back and forth.
+ 
+ EIGEN_STRONG_INLINE __device__ half operator + (const half& a, const half& b) {
+-  return __hadd(a, b);
++  return __hadd(::__half(a), ::__half(b));
+ }
+ EIGEN_STRONG_INLINE __device__ half operator * (const half& a, const half& b) {
+   return __hmul(a, b);
+@@ -218,9 +218,7 @@
+   return __hsub(a, b);
+ }
+ EIGEN_STRONG_INLINE __device__ half operator / (const half& a, const half& b) {
+-  float num = __half2float(a);
+-  float denom = __half2float(b);
+-  return __float2half(num / denom);
++  return __hdiv(a, b);
+ }
+ EIGEN_STRONG_INLINE __device__ half operator - (const half& a) {
+   return __hneg(a);


### PR DESCRIPTION
This avoids the error related to "memmapped" undeclared on Windows.