### PR TITLE
Bug 1574659 - switch CI to the new Community-TC deployment

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,8 +7,8 @@ metadata:
   owner: "{{ event.head.user.email }}" # the user who sent the pr/push e-mail will be inserted here
   source: "{{ event.head.repo.url }}"  # the repo where the pr came from will be inserted here
 tasks:
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "deepspeech-worker"
+  - provisionerId: "proj-deepspeech"
+    workerType: "ci"
     extra:
       github:
         env: true
@@ -21,9 +21,9 @@ tasks:
           - r1.14
 
     scopes: [
-      "queue:create-task:lowest:{{ taskcluster.docker.provisionerId }}/deepspeech-worker",
-      "queue:create-task:lowest:{{ taskcluster.docker.provisionerId }}/deepspeech-win-b",
-      "queue:create-task:lowest:deepspeech-provisioner/ds-macos-heavy",
+      "queue:create-task:lowest:proj-deepspeech/ci",
+      "queue:create-task:lowest:proj-deepspeech/win-b",
+      "queue:create-task:lowest:proj-deepspeech/ds-macos-heavy",
       "queue:route:index.project.deepspeech.*",
       "queue:scheduler-id:taskcluster-github"
     ]

--- a/taskcluster/worker.cyml
+++ b/taskcluster/worker.cyml
@@ -1,11 +1,11 @@
 taskcluster:
   schedulerId: taskcluster-github
   docker:
-    provisionerId: aws-provisioner-v1
-    workerType: deepspeech-worker
+    provisionerId: proj-deepspeech
+    workerType: ci
   generic:
-    provisionerId: deepspeech-provisioner
+    provisionerId: proj-deepspeech
     workerType: ds-macos-heavy
   win:
-    provisionerId: aws-provisioner-v1
-    workerType: deepspeech-win-b
+    provisionerId: proj-deepspeech
+    workerType: win-b


### PR DESCRIPTION
Similar to https://github.com/mozilla/DeepSpeech/pull/2486, this updates
the decision task to run on `proj-deepspeech/ci` and to create jobs on
the newly-named worker pools.

This repo contains no references to `taskcluster.net`, so no URLs need
to be rewritten.